### PR TITLE
Use process.env on server instead of runtimeConfig + add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/app.vue
+++ b/app.vue
@@ -1,10 +1,6 @@
 <script setup>
   import "./node_modules/bootstrap/dist/css/bootstrap.min.css"
   import "./node_modules/bootstrap-icons/font/bootstrap-icons.css"
-  // auto import of useRuntimeConfig & useAppConfig
-  const runtimeConfig = useRuntimeConfig();
-
-  const appConfig = useAppConfig();
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,12 +1,4 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-    // Env vars
-    runtimeConfig: {
-        // The private keys which are only available server-side
-        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-        // Keys within public are also exposed client-side
-        public: { }
-    },
-
     // modules: ["@nuxtjs/dotenv"]
 })

--- a/server/api/generate.ts
+++ b/server/api/generate.ts
@@ -1,7 +1,6 @@
 import { Configuration, OpenAIApi } from "openai";
 
-const runtimeConfig = useRuntimeConfig();
-const { OPENAI_API_KEY } = runtimeConfig;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 if ( ! OPENAI_API_KEY ) {
     console.log("No OpenAI API key found. Please set the OPENAI_API_KEY environment variable.");

--- a/server/api/image-generate.ts
+++ b/server/api/image-generate.ts
@@ -1,7 +1,6 @@
 import { Configuration, OpenAIApi } from "openai";
 
-const runtimeConfig = useRuntimeConfig();
-const { OPENAI_API_KEY } = runtimeConfig;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 if ( ! OPENAI_API_KEY ) {
     console.log("No OpenAI API key found. Please set the OPENAI_API_KEY environment variable.");


### PR DESCRIPTION
Instead of runtimeConfig it is easier to use .env variables directly in the sever. This way there is no need for runtimeConfig .